### PR TITLE
feat: add css modules config

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
   extends: [
     "stylelint-config-standard",
     "stylelint-config-property-sort-order-smacss",
+    "stylelint-config-css-modules",
     "./rules/base",
     "./rules/selector-bem-pattern",
   ].map(require.resolve),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "babel-eslint": "^10.1.0",
         "stylelint": "^13.13.1",
+        "stylelint-config-css-modules": "^2.3.0",
         "stylelint-config-property-sort-order-smacss": "^7.1.0",
         "stylelint-config-standard": "^20.0.0",
         "stylelint-selector-bem-pattern": "^2.1.0"
@@ -4781,6 +4782,14 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
+    "node_modules/stylelint-config-css-modules": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-2.3.0.tgz",
+      "integrity": "sha512-nSxwaJMv9wBrTAi+O4qXubyi1AR9eB36tJpY0uaFhKgEc3fwWGUzUK1Edl8AQHAoU7wmUeKtsuYjblyRP/V7rw==",
+      "peerDependencies": {
+        "stylelint": "11.x - 14.x"
+      }
+    },
     "node_modules/stylelint-config-property-sort-order-smacss": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-7.1.0.tgz",
@@ -9500,6 +9509,12 @@
           }
         }
       }
+    },
+    "stylelint-config-css-modules": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-2.3.0.tgz",
+      "integrity": "sha512-nSxwaJMv9wBrTAi+O4qXubyi1AR9eB36tJpY0uaFhKgEc3fwWGUzUK1Edl8AQHAoU7wmUeKtsuYjblyRP/V7rw==",
+      "requires": {}
     },
     "stylelint-config-property-sort-order-smacss": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
   "dependencies": {
     "babel-eslint": "^10.1.0",
     "stylelint": "^13.13.1",
-    "stylelint-config-standard": "^20.0.0",
+    "stylelint-config-css-modules": "^2.3.0",
     "stylelint-config-property-sort-order-smacss": "^7.1.0",
+    "stylelint-config-standard": "^20.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds [stylelint-config-css-modules](https://github.com/pascalduez/stylelint-config-css-modules) is order to support the full syntax of CSS modules.

I discovered this problem when I used `composes` in a [selector of ui-jobteaser](https://github.com/jobteaser/ui-jobteaser/pull/1375/files#diff-a2cb3d7a2e17c41350306cf11ba18625a78e984b0cd95e30f62bf43aee9b2d48R9) .

![Capture d’écran 2022-02-01 à 19 35 58](https://user-images.githubusercontent.com/7622399/152029743-4c67defd-bb6d-4925-9c38-8d84765803b3.png)

